### PR TITLE
[FIX] : Remove Empty `div` from GoogleTranslator Component

### DIFF
--- a/frontend/src/components/GoogleTranslate.jsx
+++ b/frontend/src/components/GoogleTranslate.jsx
@@ -16,6 +16,7 @@ const GoogleTranslate = () => {
           defaultLanguage: 'en',
         }, 'google_element');
       }
+      cleanUpGadgetText();
     };
 
     const loadGoogleTranslateScript = () => {
@@ -27,8 +28,21 @@ const GoogleTranslate = () => {
         script.onerror = () => console.error('Error loading Google Translate script');
         document.body.appendChild(script);
       }
+      
     };
+    
 
+    const cleanUpGadgetText = () => {
+      const gadgetElement = document.querySelector('.goog-te-gadget');
+      if (gadgetElement) {
+        const textNodes = gadgetElement.childNodes;
+        textNodes.forEach((node) => {
+          if (node.nodeType === Node.TEXT_NODE) {
+            node.textContent = ''; // Clear text content
+          }
+        });
+      }
+    };
     loadGoogleTranslateScript();
 
     if (window.google && window.google.translate) {


### PR DESCRIPTION
# Pull Request: Remove Empty `div` from GoogleTranslator Component

### Title
Remove Empty `div` in GoogleTranslator Component to Fix Navbar UI Disturbance

### Description
This pull request addresses the issue of an empty `div` present in the `GoogleTranslator` component, which was causing visual disturbances and layout issues in the navbar. The unnecessary `div` has been removed to ensure a cleaner UI and improved alignment of the navbar.

### Related Issues
Fixes #327 

### Changes Made
- Removed the empty `div` from the `GoogleTranslator` component.
- Verified that the navbar UI is now displaying correctly without any disturbances.

### Checklist
- [x] I have tested the changes locally

### Screenshots (if applicable)

- Previously
<img width="1280" alt="Screenshot 2024-10-12 at 3 08 21 AM" src="https://github.com/user-attachments/assets/399dff2f-ca5f-475e-ba5d-898adeccb4a2">

- Now
<img width="1279" alt="Screenshot 2024-10-12 at 3 19 08 AM" src="https://github.com/user-attachments/assets/847e2a0a-5624-4d43-a86c-db101658d721">


