### PR TITLE
Added Seed Quality Prediction Model

### DIFF
--- a/seed-qual-predictor/README.md
+++ b/seed-qual-predictor/README.md
@@ -1,0 +1,51 @@
+# Seed Quality Prediction API for Maize
+
+This project provides a Flask-based API to predict the quality of maize seeds using a Convolutional Neural Network (CNN) model. The API can classify seeds into three categories: broken, discolored, and pure, helping to automate the quality assessment process.
+
+## Classes in the Prediction Result
+The model predicts the following classes for maize seed quality:
+
+- `broken` - seeds that are physically damaged or incomplete.
+- `discolored` - seeds that show abnormal coloration, often an indicator of lower quality.
+- `pure` - seeds that are in optimal condition for planting.
+
+## Model Architecture
+The model used for prediction is a Convolutional Neural Network (CNN) trained on grayscale images of maize seeds, with the following architecture:
+
+- Conv2D layers for feature extraction.
+- MaxPooling2D layers for down-sampling.
+- Dense layers for classification with a softmax activation function to output class probabilities.
+
+The model was trained using TensorFlow and Keras, with the saved model (`model.h5`) being loaded for inference.
+
+## API Usage
+The API exposes a `/predict` endpoint to which you can send an image of a maize seed for classification. The API responds with the predicted class and the model's confidence in the prediction.
+
+### Endpoint: `/predict`
+- Method: POST
+- Content-Type: multipart/form-data
+- Required: Upload a seed image.
+
+## File Structure
+```
+.
+├── app.py                # Flask API code
+├── model
+│   └── model.h5          # Trained CNN model
+├── uploads               # Directory for temporarily storing uploaded files
+├── requirements.txt      # List of dependencies
+└── README.md             # Project readme file
+```
+
+## Running the API
+> Fork the repo first!
+- 1. Clone the repository:
+```
+git clone https://github.com/your-repo/AgroTech-AI.git
+cd seed-quality-predictor
+```
+- 2. Run the Flask app:
+```
+cd seed-quality-predictor
+python app.py
+```

--- a/seed-qual-predictor/app.py
+++ b/seed-qual-predictor/app.py
@@ -1,0 +1,65 @@
+from flask import Flask, request, jsonify
+import numpy as np
+import cv2
+from tensorflow import keras
+import os
+
+# Initialize the Flask application
+app = Flask(__name__)
+
+# Load the model
+model = keras.models.load_model('model/model.h5')
+categories = ["broken", "discolored", "pure"]
+
+# Set the image size
+SIZE = 120
+
+def preprocess_image(image_path):
+    """Preprocess the image for prediction."""
+    # Read the image
+    nimage = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
+    # Resize and normalize the image
+    image = cv2.resize(nimage, (SIZE, SIZE)) / 255.0
+    return np.array(image).reshape(-1, SIZE, SIZE, 1)
+
+@app.route('/')
+def index():
+    return "Welcome to the Seed Quality Prediction API!"
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    """API endpoint for predicting seed quality."""
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file provided'}), 400
+
+    file = request.files['file']
+
+    if not file:
+        return jsonify({'error': 'No file provided'}), 400
+
+    # Save the uploaded file temporarily
+    image_path = os.path.join('./uploads', file.filename)
+    file.save(image_path)
+
+    # Preprocess the image
+    processed_image = preprocess_image(image_path)
+
+    # Make prediction
+    prediction = model.predict(processed_image)
+    pclass = np.argmax(prediction)
+
+    # Prepare the response
+    result = {
+        'class': categories[pclass],
+        'confidence': float(np.max(prediction))
+    }
+
+    # Optionally delete the uploaded file
+    os.remove(image_path)
+
+    return jsonify(result)
+
+if __name__ == '__main__':
+    # Create uploads directory if not exists
+    os.makedirs('./uploads', exist_ok=True)
+    app.run(host='0.0.0.0', port=5000)

--- a/seed-qual-predictor/requirements.txt
+++ b/seed-qual-predictor/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+tensorflow
+opencv-python
+numpy
+flask-cors
+gunicorn


### PR DESCRIPTION
# Pull Request

### Title
Added Seed Quality Prediction Model for maize seeds

### Description
This is a Flask-based API for predicting maize seed quality using a CNN model. It includes the model (`model.h5`), endpoints for image upload and classification, and a `/predict` route to return seed quality (broken, discolored, or pure) along with confidence scores. Basic file structure and necessary setup for deployment using Gunicorn are also provided.
### Related Issues
Fixes #303 

### Changes Made
<!-- List of changes made in the PR (e.g., new features, bug fixes, improvements) -->

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [x] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)
<!-- Add any relevant screenshots to illustrate the changes -->
![Screenshot 2024-10-12 233331](https://github.com/user-attachments/assets/5dac3b82-4594-4245-ba98-6210143c2bd6)


### Additional Notes
I tested it using POSTMAN and I am excited to share that it is working fine!

