### PR TITLE
 View Report and Download pdf button functioning in fertilizer prediction page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.5",
         "framer-motion": "^11.2.13",
+        "jspdf": "^2.5.2",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.451.0",
         "mapbox-gl": "^3.7.0",
@@ -2812,6 +2813,12 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
@@ -3108,6 +3115,17 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -3204,6 +3222,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3306,6 +3333,17 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -3383,6 +3421,31 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -3523,6 +3586,17 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/core-js": {
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -3557,6 +3631,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csscolorparser": {
@@ -3748,6 +3831,12 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
+      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q==",
+      "optional": true
     },
     "node_modules/dotenv": {
       "version": "16.4.5",
@@ -4363,6 +4452,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4793,6 +4887,19 @@
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ieee754": {
@@ -5383,6 +5490,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -5916,6 +6040,12 @@
         "pbf": "bin/pbf"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
@@ -6199,6 +6329,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -6534,6 +6673,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6763,6 +6911,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/string-width": {
@@ -7050,6 +7207,15 @@
         "react": ">=17.0"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
@@ -7122,6 +7288,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -7412,6 +7587,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.5",
     "framer-motion": "^11.2.13",
+    "jspdf": "^2.5.2",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.451.0",
     "mapbox-gl": "^3.7.0",

--- a/frontend/src/components/models/Fertilizer.jsx
+++ b/frontend/src/components/models/Fertilizer.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
+import jsPDF from "jspdf";
 
 export default function Component() {
   const [loading, setLoading] = useState(true)
@@ -18,6 +19,7 @@ export default function Component() {
   })
   const [result, setResult] = useState("")
   const [isLoading, setIsLoading] = useState(false)
+  const [showReport, setShowReport] = useState(false);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -44,36 +46,60 @@ export default function Component() {
     const jsonData = JSON.stringify(formData);
     console.log("Sending data:", jsonData); // Log the data being sent
     fetch(url, {
-        headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-        },
-        method: "POST",
-        body: jsonData,
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      body: jsonData,
     })
-        .then((response) => {
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            return response.json();
-        })
-        .then((response) => {
-            console.log("Received response:", response); // Log the response
-            setResult(response.Prediction);
-            setIsLoading(false);
-            setShowSpan(true);
-        })
-        .catch((error) => {
-            console.error("Error:", error);
-            setIsLoading(false);
-            setShowSpan(true);
-            setResult("Error: Unable to predict fertilizer");
-        });
-};
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((response) => {
+        console.log("Received response:", response); // Log the response
+        setResult(response.Prediction);
+        setIsLoading(false);
+        setShowSpan(true);
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+        setIsLoading(false);
+        setShowSpan(true);
+        setResult("Error: Unable to predict fertilizer");
+      });
+  };
 
   if (loading) {
     return <div className="flex items-center justify-center h-screen text-xl">Loading...</div>
   }
+  // Handle view report
+  const handleViewReport = () => {
+    setShowReport(true); // Show the report when the button is clicked
+  };
+
+  // Handle download report as PDF
+  const handleDownloadPdf = () => {
+    const doc = new jsPDF();
+    doc.text(
+      `Fertilizer Prediction Report:
+      \nTemperature: ${formData.Temparature}
+      \nHumidity: ${formData.Humidity}
+      \nMoisture: ${formData.Moisture}
+      \nSoil Type: ${formData.Soil_Type}
+      \nCrop Type: ${formData.Crop_Type}
+      \nNitrogen: ${formData.Nitrogen}
+      \nPotassium: ${formData.Potassium}
+      \nPhosphorous: ${formData.Phosphorous}
+      \nPrediction: ${result}`,
+      10,
+      10
+    );
+    doc.save("fertilizer_report.pdf");
+  };
 
   return (
     <div className={`min-h-screen ${darkMode ? 'bg-gray-900 text-white' : 'bg-gradient-to-br from-green-50 to-green-100'} py-20`}>
@@ -198,152 +224,152 @@ export default function Component() {
             </div>
 
             <form onSubmit={handlePredictClick} className={`${darkMode ? 'bg-gray-800' : 'bg-white'} shadow-lg rounded-lg overflow-hidden p-6`}>
-                <h2 className="text-2xl font-bold text-green-600 mb-4">Predict Fertilizer</h2>
-                
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    {/* Inputs for Temparature, Humidity, and Moisture */}
-                    <div className="mb-4">
-                    <label className="block text-base font-medium mb-2" htmlFor="Temparature">Temparature</label>
-                    <input
-                        type="text"
-                        id="Temparature"
-                        name="Temparature"
-                        value={formData.Temparature}
-                        onChange={handleChange}
-                        className="w-full px-3 py-2 text-base border rounded-md text-black"
-                        placeholder="1 to 50°C"
-                        required
-                    />
-                    </div>
+              <h2 className="text-2xl font-bold text-green-600 mb-4">Predict Fertilizer</h2>
 
-                    <div className="mb-4">
-                    <label className="block text-base font-medium mb-2" htmlFor="Humidity">Humidity</label>
-                    <input
-                        type="text"
-                        id="Humidity"
-                        name="Humidity"
-                        value={formData.Humidity}
-                        onChange={handleChange}
-                        className="w-full px-3 py-2 text-base border rounded-md text-black"
-                        placeholder="1 to 100%"
-                        required
-                    />
-                    </div>
-
-                    <div className="mb-4">
-                    <label className="block text-base font-medium mb-2" htmlFor="Moisture">Moisture</label>
-                    <input
-                        type="text"
-                        id="Moisture"
-                        name="Moisture"
-                        value={formData.Moisture}
-                        onChange={handleChange}
-                        className="w-full px-3 py-2 text-base border rounded-md text-black"
-                        placeholder="1 to 100%"
-                        required
-                    />
-                    </div>
-
-                    {/* Dropdowns for Soil Type and Crop Type */}
-                    <div className="mb-4">
-                    <label className="block text-base font-medium mb-2" htmlFor="Soil_Type">Soil Type</label>
-                    <select
-                        className= {`w-full px-3 py-2 border rounded-md ${darkMode ? 'text-black' : 'text-black'}`}
-                        id="Soil_Type"
-                        name="Soil_Type"
-                        value={formData.Soil_Type}
-                        onChange={handleChange}
-                        required
-                    >
-                        <option value="" disabled>Select</option>
-                        <option value="0">Black</option>
-                        <option value="1">Clayey</option>
-                        <option value="2">Loamy</option>
-                        <option value="3">Red</option>
-                        <option value="4">Sandy</option>
-                    </select>
-                    </div>
-
-                    <div className="mb-4">
-                    <label className="block text-base font-medium mb-2" htmlFor="Crop_Type">Crop Type</label>
-                    <select
-                        className={`w-full px-3 py-2 border rounded-md ${darkMode ? 'text-black' : 'text-black'}`}
-                        id="Crop_Type"
-                        name="Crop_Type"
-                        value={formData.Crop_Type}
-                        onChange={handleChange}
-                        required
-                    >
-                        <option value="" disabled>Select</option>
-                        <option value="0">Barley</option>
-                        <option value="1">Cotton</option>
-                        <option value="2">Ground Nuts</option>
-                        <option value="3">Maize</option>
-                        <option value="4">Millets</option>
-                        <option value="5">Oil Seeds</option>
-                        <option value="6">Paddy</option>
-                        <option value="7">Pulses</option>
-                        <option value="8">Sugarcane</option>
-                        <option value="9">Tobacco</option>
-                        <option value="10">Wheat</option>
-                    </select>
-                    </div>
-
-                    {/* Inputs for Nitrogen, Potassium, and Phosphorous */}
-                    <div className="mb-4">
-                    <label className="block text-base font-medium mb-2 " htmlFor="Nitrogen">Nitrogen</label>
-                    <input
-                        type="text"
-                        id="Nitrogen"
-                        name="Nitrogen"
-                        value={formData.Nitrogen}
-                        onChange={handleChange}
-                        className="w-full px-3 py-2 text-base border rounded-md text-black"
-                        placeholder="1 to 50"
-                        required
-                    />
-                    </div>
-
-                    <div className="mb-4">
-                    <label className="block text-base font-medium mb-2" htmlFor="Potassium">Potassium</label>
-                    <input
-                        type="text"
-                        id="Potassium"
-                        name="Potassium"
-                        value={formData.Potassium}
-                        onChange={handleChange}
-                        className="w-full px-3 py-2 text-base border rounded-md text-black"
-                        placeholder="1 to 50"
-                        required
-                    />
-                    </div>
-
-                    <div className="mb-4">
-                    <label className="block text-base font-medium mb-2" htmlFor="Phosphorous">Phosphorous</label>
-                    <input
-                        type="text"
-                        id="Phosphorous"
-                        name="Phosphorous"
-                        value={formData.Phosphorous}
-                        onChange={handleChange}
-                        className="w-full px-3 py-2 text-base border rounded-md text-black"
-                        placeholder="1 to 50"
-                        required
-                    />
-                    </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {/* Inputs for Temparature, Humidity, and Moisture */}
+                <div className="mb-4">
+                  <label className="block text-base font-medium mb-2" htmlFor="Temparature">Temparature</label>
+                  <input
+                    type="text"
+                    id="Temparature"
+                    name="Temparature"
+                    value={formData.Temparature}
+                    onChange={handleChange}
+                    className="w-full px-3 py-2 text-base border rounded-md text-black"
+                    placeholder="1 to 50°C"
+                    required
+                  />
                 </div>
 
-                <button
-                    type="submit"
-                    disabled={isLoading}
-                    className={`w-full mt-4 px-6 py-3 text-lg text-white font-semibold rounded-lg ${isLoading ? 'bg-gray-400 cursor-not-allowed' : 'bg-green-500 hover:bg-green-600'}`}
-                >
-                    {isLoading ? 'Predicting...' : 'Predict Fertilizer'}
-                </button>
-                </form>
+                <div className="mb-4">
+                  <label className="block text-base font-medium mb-2" htmlFor="Humidity">Humidity</label>
+                  <input
+                    type="text"
+                    id="Humidity"
+                    name="Humidity"
+                    value={formData.Humidity}
+                    onChange={handleChange}
+                    className="w-full px-3 py-2 text-base border rounded-md text-black"
+                    placeholder="1 to 100%"
+                    required
+                  />
+                </div>
+
+                <div className="mb-4">
+                  <label className="block text-base font-medium mb-2" htmlFor="Moisture">Moisture</label>
+                  <input
+                    type="text"
+                    id="Moisture"
+                    name="Moisture"
+                    value={formData.Moisture}
+                    onChange={handleChange}
+                    className="w-full px-3 py-2 text-base border rounded-md text-black"
+                    placeholder="1 to 100%"
+                    required
+                  />
+                </div>
+
+                {/* Dropdowns for Soil Type and Crop Type */}
+                <div className="mb-4">
+                  <label className="block text-base font-medium mb-2" htmlFor="Soil_Type">Soil Type</label>
+                  <select
+                    className= {`w-full px-3 py-2 border rounded-md ${darkMode ? 'text-black' : 'text-black'}`}
+                    id="Soil_Type"
+                    name="Soil_Type"
+                    value={formData.Soil_Type}
+                    onChange={handleChange}
+                    required
+                  >
+                    <option value="" disabled>Select</option>
+                    <option value="0">Black</option>
+                    <option value="1">Clayey</option>
+                    <option value="2">Loamy</option>
+                    <option value="3">Red</option>
+                    <option value="4">Sandy</option>
+                  </select>
+                </div>
+
+                <div className="mb-4">
+                  <label className="block text-base font-medium mb-2" htmlFor="Crop_Type">Crop Type</label>
+                  <select
+                    className={`w-full px-3 py-2 border rounded-md ${darkMode ? 'text-black' : 'text-black'}`}
+                    id="Crop_Type"
+                    name="Crop_Type"
+                    value={formData.Crop_Type}
+                    onChange={handleChange}
+                    required
+                  >
+                    <option value="" disabled>Select</option>
+                    <option value="0">Barley</option>
+                    <option value="1">Cotton</option>
+                    <option value="2">Ground Nuts</option>
+                    <option value="3">Maize</option>
+                    <option value="4">Millets</option>
+                    <option value="5">Oil Seeds</option>
+                    <option value="6">Paddy</option>
+                    <option value="7">Pulses</option>
+                    <option value="8">Sugarcane</option>
+                    <option value="9">Tobacco</option>
+                    <option value="10">Wheat</option>
+                  </select>
+                </div>
+
+                {/* Inputs for Nitrogen, Potassium, and Phosphorous */}
+                <div className="mb-4">
+                  <label className="block text-base font-medium mb-2 " htmlFor="Nitrogen">Nitrogen</label>
+                  <input
+                    type="text"
+                    id="Nitrogen"
+                    name="Nitrogen"
+                    value={formData.Nitrogen}
+                    onChange={handleChange}
+                    className="w-full px-3 py-2 text-base border rounded-md text-black"
+                    placeholder="1 to 50"
+                    required
+                  />
+                </div>
+
+                <div className="mb-4">
+                  <label className="block text-base font-medium mb-2" htmlFor="Potassium">Potassium</label>
+                  <input
+                    type="text"
+                    id="Potassium"
+                    name="Potassium"
+                    value={formData.Potassium}
+                    onChange={handleChange}
+                    className="w-full px-3 py-2 text-base border rounded-md text-black"
+                    placeholder="1 to 50"
+                    required
+                  />
+                </div>
+
+                <div className="mb-4">
+                  <label className="block text-base font-medium mb-2" htmlFor="Phosphorous">Phosphorous</label>
+                  <input
+                    type="text"
+                    id="Phosphorous"
+                    name="Phosphorous"
+                    value={formData.Phosphorous}
+                    onChange={handleChange}
+                    className="w-full px-3 py-2 text-base border rounded-md text-black"
+                    placeholder="1 to 50"
+                    required
+                  />
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className={`w-full mt-4 px-6 py-3 text-lg text-white font-semibold rounded-lg ${isLoading ? 'bg-gray-400 cursor-not-allowed' : 'bg-green-500 hover:bg-green-600'}`}
+              >
+                {isLoading ? 'Predicting...' : 'Predict Fertilizer'}
+              </button>
+            </form>
 
 
-                {(result || isLoading) && (
+            {(result || isLoading) && (
               <div className={`${darkMode ? 'bg-gray-800' : 'bg-white'} shadow-lg rounded-lg overflow-hidden mt-6 p-6`}>
                 <h2 className="text-2xl font-bold text-green-600 mb-4">Prediction Result</h2>
                 {isLoading ? (
@@ -355,26 +381,72 @@ export default function Component() {
             )}
           </div>
         </div>
+        
+        <div>
+          <div className="mt-6 flex flex-wrap justify-center space-x-4">
+            <button
+              onClick={handleViewReport}
+              className="bg-white text-green-600 px-6 py-2 rounded-lg shadow hover:bg-green-50 text-lg mb-4"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 inline-block mr-2"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                />
+              </svg>
+              View Report
+            </button>
+            <button className="bg-white text-green-600 px-6 py-2 rounded-lg shadow hover:bg-green-50 text-lg mb-4">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 inline-block mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              Compare Options
+            </button>
+            <button
+              onClick={handleDownloadPdf}
+              className="bg-white text-green-600 px-6 py-2 rounded-lg shadow hover:bg-green-50 text-lg mb-4"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 inline-block mr-2"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                />
+              </svg>
+              Download PDF
+            </button>
+          </div>
 
-        <div className="mt-6 flex flex-wrap justify-center space-x-4">
-          <button className="bg-white text-green-600 px-6 py-2 rounded-lg shadow hover:bg-green-50 text-lg mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 inline-block mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-            </svg>
-            View Report
-          </button>
-          <button className="bg-white text-green-600 px-6 py-2 rounded-lg shadow hover:bg-green-50 text-lg mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 inline-block mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
-            Compare Options
-          </button>
-          <button className="bg-white text-green-600 px-6 py-2 rounded-lg shadow hover:bg-green-50 text-lg mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 inline-block mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-            </svg>
-            Download PDF
-          </button>
+          {/* Conditionally render the report */}
+          {showReport && (
+            <div className="mt-6 bg-white p-4 rounded-lg shadow-md">
+              <h2 className="text-xl font-semibold mb-4">Fertilizer Prediction Report</h2>
+              <p><strong>Temperature:</strong> {formData.Temparature}</p>
+              <p><strong>Humidity:</strong> {formData.Humidity}</p>
+              <p><strong>Moisture:</strong> {formData.Moisture}</p>
+              <p><strong>Soil Type:</strong> {formData.Soil_Type}</p>
+              <p><strong>Crop Type:</strong> {formData.Crop_Type}</p>
+              <p><strong>Nitrogen:</strong> {formData.Nitrogen}</p>
+              <p><strong>Potassium:</strong> {formData.Potassium}</p>
+              <p><strong>Phosphorous:</strong> {formData.Phosphorous}</p>
+              <p><strong>Prediction:</strong> {result}</p>
+            </div>
+          )}
         </div>
 
         <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">


### PR DESCRIPTION
Fertilizer Prediction Page

# Pull Request

### Title
 View Report and Download pdf button functioning in fertilizer prediction page

### Description
This PR introduces a feature to view and download a fertilizer prediction report based on the form inputs and prediction result. The report is displayed on the page when the user clicks the "View Report" button, and it includes details such as temperature, humidity, soil type, and prediction results. Users can also download the report as a PDF using the "Download PDF" button.

### Related Issues
Fixes ##583

### Changes Made
- Implemented a  button for "View Report" that conditionally renders the report on the page.
- Installed npm package for jspdf ['npm i jspdf']
- Integrated jsPDF for generating and downloading the report in PDF format.

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [x] I have tested the changes locally
- [ ] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Screenshots (if applicable)
![ViewReport](https://github.com/user-attachments/assets/692c042b-eff3-4c7e-9ced-a99586d9d35a)
![Download pdf](https://github.com/user-attachments/assets/0d3d3346-bbd1-42d7-8bc5-387188b0998c)

### Additional Notes
Installed npm package for jspdf in fronted folder

