### PR TITLE
[Fixed] Login State Persistence and User Data Return on Login

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -27,8 +27,9 @@ exports.signupController = async (req, res) => {
 
 
 exports.signinController = async (req, res) => {
+
   try {
-    const { email, password } = req.body;
+    const { email, password } = req.body; // Log the request body
     const user = await User.findOne({ email });
 
     if (!user) {
@@ -43,7 +44,8 @@ exports.signinController = async (req, res) => {
     // Include role in the token
     const token = jwt.sign({ userId: user._id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
 
-    res.status(200).json({ message: 'Login successful', token });
+    const user_id = user._id.toString()
+    res.status(200).json({ message: 'Login successful', token , user_id});
   } catch (error) {
     console.error("Login error:", error);
     res.status(500).json({ message: 'Login failed' });

--- a/frontend/src/components/LoginPage.jsx
+++ b/frontend/src/components/LoginPage.jsx
@@ -23,7 +23,7 @@ const LoginPage = () => {
           password,
         }
       );
-      login(response.data.token); // Call login method from context
+      login(response.data.token, response.data.user_id); // Call login method from context
       toast.success("Login successful");
     } catch (error) {
       toast.error(error.response?.data?.message || "Login failed");

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,22 +1,43 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
 
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [userData, setUserData] = useState(null);
+  // Initialize the logged-in state from localStorage
+  const [isLoggedIn, setIsLoggedIn] = useState(() => {
+    const authData = localStorage.getItem('auth');
+    return authData ? true : false;
+  });
+
+  // Initialize user data from localStorage
+  const [userData, setUserData] = useState(() => {
+    const authData = localStorage.getItem('auth');
+    return authData ? JSON.parse(authData).user : null;
+  });
 
   const login = (token, user) => {
+    // Store authentication data in localStorage
     localStorage.setItem('auth', JSON.stringify({ token, user }));
     setIsLoggedIn(true);
-    setUserData(user); // Set user data which includes role
+    setUserData(user);
   };
 
   const logout = () => {
+    // Remove authentication data from localStorage
     localStorage.removeItem('auth');
     setIsLoggedIn(false);
     setUserData(null);
   };
+
+  // Effect to set user data when the component mounts
+  useEffect(() => {
+    const authData = localStorage.getItem('auth');
+    if (authData) {
+      const { user } = JSON.parse(authData);
+      setUserData(user);
+      setIsLoggedIn(true);
+    }
+  }, []);
 
   return (
     <AuthContext.Provider value={{ isLoggedIn, login, logout, userData }}>
@@ -26,3 +47,4 @@ export const AuthProvider = ({ children }) => {
 };
 
 export const useAuth = () => useContext(AuthContext);
+


### PR DESCRIPTION
### Description
This pull request addresses two significant issues regarding user authentication:

- Login State Persistence: Users are logged out after refreshing the page due to the login state not being stored in local storage.
- User Data Return: The backend does not return the user data after a successful login, hindering proper user session management.

### Changes Made
- Frontend Adjustments
    - Updated the authentication context to check local storage for existing login state upon initialization.
    - Ensured user data is retrieved and stored in context after login.
- Backend Adjustments
    - Modified the signinController to return user id along with the token upon successful authentication.

### Related Issues
- Closes #705 

### Checklist 

- [x] I have tested the changes locally
- [ ] Documentation has been updated (if necessary)
- [x] Changes are backward-compatible

### Video

https://github.com/user-attachments/assets/f296bf84-79b4-4f50-8823-b9ad162d3885



