### PR TITLE
Implemented Product Return Feature with routes, schema and Controllers for advance feature

### DIFF
--- a/backend/controllers/shop/sub-controllers/returnController.js
+++ b/backend/controllers/shop/sub-controllers/returnController.js
@@ -1,0 +1,229 @@
+
+const ReturnProduct = require('../models/ReturnProduct');
+const Product = require('../models/Product');
+const User = require('../models/User');
+
+// Create Return (POST /api/returns)
+exports.createReturn = async (req, res) => {
+  try {
+    const { productId, returnDate, condition } = req.body;
+    const userId = req.user.id; // Assuming user authentication is in place
+
+    const product = await Product.findById(productId);
+    if (!product) {
+      return res.status(404).json({ message: 'Product not found.' });
+    }
+
+    // Check if the product has already been returned
+    const existingReturn = await ReturnProduct.findOne({ productId, userId, status: 'returned' });
+    if (existingReturn) {
+      return res.status(400).json({ message: 'Product has already been returned.' });
+    }
+
+    const returnRequest = new ReturnProduct({
+      productId,
+      userId,
+      returnDate,
+      condition,
+      status: 'pending'
+    });
+
+    await returnRequest.save();
+    res.status(201).json({ message: 'Return request created successfully.', returnRequest });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error.', error: err.message });
+  }
+};
+
+// Update Return Status (PATCH /api/returns/:id)
+exports.updateReturnStatus = async (req, res) => {
+  try {
+    const { status } = req.body;
+    const returnId = req.params.id;
+
+    if (!['approved', 'rejected'].includes(status)) {
+      return res.status(400).json({ message: 'Invalid status.' });
+    }
+
+    const returnRequest = await ReturnProduct.findById(returnId);
+    if (!returnRequest) {
+      return res.status(404).json({ message: 'Return request not found.' });
+    }
+
+    // Ensure that only admins can update the status
+    if (!req.user.isAdmin) {
+      return res.status(403).json({ message: 'Admin access required.' });
+    }
+
+    returnRequest.status = status;
+    returnRequest.updatedAt = Date.now();
+    await returnRequest.save();
+
+    res.status(200).json({ message: 'Return status updated successfully.', returnRequest });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error.', error: err.message });
+  }
+};
+
+// Get Return Information (GET /api/returns/:id)
+exports.getReturnInformation = async (req, res) => {
+  try {
+    const returnId = req.params.id;
+    const returnRequest = await ReturnProduct.findById(returnId)
+      .populate('productId')
+      .populate('userId');
+
+    if (!returnRequest) {
+      return res.status(404).json({ message: 'Return request not found.' });
+    }
+
+    // Check if the user is authorized to view return details
+    if (req.user.id !== returnRequest.userId.toString() && !req.user.isAdmin) {
+      return res.status(403).json({ message: 'Unauthorized access.' });
+    }
+
+    res.status(200).json(returnRequest);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error.', error: err.message });
+  }
+};
+
+// Get User’s Return History (GET /api/returns/user/:userId)
+exports.getUserReturnHistory = async (req, res) => {
+  try {
+    const userId = req.params.userId;
+
+    if (req.user.id !== userId && !req.user.isAdmin) {
+      return res.status(403).json({ message: 'Unauthorized access.' });
+    }
+
+    const returnHistory = await ReturnProduct.find({ userId })
+      .populate('productId')
+      .populate('userId');
+
+    if (!returnHistory.length) {
+      return res.status(404).json({ message: 'No return history found.' });
+    }
+
+    res.status(200).json(returnHistory);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error.', error: err.message });
+  }
+};
+
+// Get All Pending Returns (GET /api/returns/pending)
+exports.getPendingReturns = async (req, res) => {
+  try {
+    if (!req.user.isAdmin) {
+      return res.status(403).json({ message: 'Admin access required.' });
+    }
+
+    const pendingReturns = await ReturnProduct.find({ status: 'pending' })
+      .populate('productId')
+      .populate('userId');
+
+    if (!pendingReturns.length) {
+      return res.status(404).json({ message: 'No pending returns found.' });
+    }
+
+    res.status(200).json(pendingReturns);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error.', error: err.message });
+  }
+};
+
+// Cancel Return Request (PATCH /api/returns/cancel/:id)
+exports.cancelReturnRequest = async (req, res) => {
+    try {
+      const returnId = req.params.id;
+      const returnRequest = await ReturnProduct.findById(returnId);
+  
+      if (!returnRequest) {
+        return res.status(404).json({ message: 'Return request not found.' });
+      }
+  
+      // Check if the return request is still pending
+      if (returnRequest.status !== 'pending') {
+        return res.status(400).json({ message: 'Return request cannot be canceled once it is processed.' });
+      }
+  
+      // Ensure that the user is the one who made the return request
+      if (returnRequest.userId.toString() !== req.user.id) {
+        return res.status(403).json({ message: 'You are not authorized to cancel this return request.' });
+      }
+  
+      returnRequest.status = 'canceled';
+      returnRequest.updatedAt = Date.now();
+      await returnRequest.save();
+  
+      res.status(200).json({ message: 'Return request canceled successfully.', returnRequest });
+    } catch (err) {
+      res.status(500).json({ message: 'Server error.', error: err.message });
+    }
+  };
+
+  // Get All Returned Products (GET /api/returns/returned)
+exports.getAllReturnedProducts = async (req, res) => {
+    try {
+      if (!req.user.isAdmin) {
+        return res.status(403).json({ message: 'Admin access required.' });
+      }
+  
+      const returnedProducts = await ReturnProduct.find({ status: 'returned' })
+        .populate('productId')
+        .populate('userId');
+  
+      if (!returnedProducts.length) {
+        return res.status(404).json({ message: 'No returned products found.' });
+      }
+  
+      res.status(200).json(returnedProducts);
+    } catch (err) {
+      res.status(500).json({ message: 'Server error.', error: err.message });
+    }
+  };
+
+  // Get All Damaged Products (GET /api/returns/damaged)
+exports.getAllDamagedProducts = async (req, res) => {
+    try {
+      if (!req.user.isAdmin) {
+        return res.status(403).json({ message: 'Admin access required.' });
+      }
+  
+      const damagedProducts = await ReturnProduct.find({ condition: 'damaged' })
+        .populate('productId')
+        .populate('userId');
+  
+      if (!damagedProducts.length) {
+        return res.status(404).json({ message: 'No damaged products found.' });
+      }
+  
+      res.status(200).json(damagedProducts);
+    } catch (err) {
+      res.status(500).json({ message: 'Server error.', error: err.message });
+    }
+  };
+
+  // Get Return Requests for a Specific Product (GET /api/returns/product/:productId)
+exports.getReturnRequestsForProduct = async (req, res) => {
+    try {
+      const { productId } = req.params;
+  
+      if (!req.user.isAdmin) {
+        return res.status(403).json({ message: 'Admin access required.' });
+      }
+  
+      const returnRequests = await ReturnProduct.find({ productId })
+        .populate('productId')
+        .populate('userId');
+  
+      if (!returnRequests.length) {
+        return res.status(404).json({ message: 'No return requests found for this product.' });
+      }
+  
+      res.status(200).json(returnRequests);
+    } catch (err) {
+      res.status(500).json({ message: 'Server error.', error: err.message });
+    }
+  };
+  

--- a/backend/model/shop/sub-model/ReturnProduct.js
+++ b/backend/model/shop/sub-model/ReturnProduct.js
@@ -1,0 +1,42 @@
+
+const mongoose = require('mongoose');
+
+const returnProductSchema = new mongoose.Schema(
+  {
+    productId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Product',
+      required: true
+    },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true
+    },
+    returnDate: {
+      type: Date,
+      required: true
+    },
+    condition: {
+      type: String,
+      enum: ['good', 'damaged'],
+      required: true
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'returned', 'approved', 'rejected'],
+      default: 'pending'
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now
+    },
+    updatedAt: {
+      type: Date,
+      default: Date.now
+    }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('ReturnProduct', returnProductSchema);

--- a/backend/routes/sub-routes/returnRoutes.js
+++ b/backend/routes/sub-routes/returnRoutes.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const router = express.Router();
+const { createReturn, updateReturnStatus, getReturnInformation, getUserReturnHistory, getPendingReturns, cancelReturnRequest, getAllReturnedProducts, getAllDamagedProducts, getReturnRequestsForProduct } = require('../../controllers/shop/sub-controllers/returnController');
+const { authenticateUser, authorizeAdmin } = require('../middleware/auth');
+
+// Route to create a return request
+router.post('/returns', authenticateUser, createReturn);
+
+// Route to update return status (Admin only)
+router.patch('/returns/:id', authenticateUser, authorizeAdmin, updateReturnStatus);
+
+// Route to get return information
+router.get('/returns/:id', authenticateUser, getReturnInformation);
+
+// Route to get a user's return history
+router.get('/returns/user/:userId', authenticateUser, getUserReturnHistory);
+
+// Route to get all pending returns (Admin only)
+router.get('/returns/pending', authenticateUser, authorizeAdmin, getPendingReturns);
+
+// Route to cancel return request
+router.patch('/returns/cancel/:id', authenticateUser, cancelReturnRequest);
+
+// Route to get all returned products (Admin only)
+router.get('/returns/returned', authenticateUser, authorizeAdmin, getAllReturnedProducts);
+
+// Route to get all damaged products (Admin only)
+router.get('/returns/damaged', authenticateUser, authorizeAdmin, getAllDamagedProducts);
+
+// Route to get return requests for a specific product (Admin only)
+router.get('/returns/product/:productId', authenticateUser, authorizeAdmin, getReturnRequestsForProduct);
+
+module.exports = router;


### PR DESCRIPTION
#### Overview:
This pull request implements the product return feature, which includes the creation, management, and tracking of product return requests. The functionality allows users to initiate return requests, admins to approve or reject them, and users to track their return history. The following routes and schema have been added to manage product returns effectively.

---

#### Routes:
1. **POST /api/returns** - Create a return request
2. **PATCH /api/returns/:id** - Update the return status (admin only)
3. **GET /api/returns/:id** - Get detailed information of a return request
4. **GET /api/returns/user/:userId** - Get the return history of a user
5. **GET /api/returns/pending** - Get all pending return requests (admin only)
6. **PATCH /api/returns/cancel/:id** - Cancel a return request
7. **GET /api/returns/returned** - Get all returned products (admin only)
8. **GET /api/returns/damaged** - Get all damaged products (admin only)
9. **GET /api/returns/product/:productId** - Get all return requests for a specific product (admin only)

---

#### Schema:
1. **ReturnProduct Schema**:
   - Represents the return request details, including product ID, user ID, return date, condition of the product, status of the request, and timestamps.
   - The `status` field tracks whether the return is "pending," "approved," "rejected," or "returned."
   - The `condition` field allows tracking of the product's condition ("damaged" or "good").
   - References to `Product` and `User` models for related data (populated in controllers).

- closes #883 
